### PR TITLE
Rework release preparation tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,19 @@ Then, at the top of your `Rakefile`, add:
 require 'voxpupuli-release'
 ```
 
-To cut a new release of your module, ensure the `metadata.json` reflects the proper version. Also ensure that the `CHANGELOG.md` has a note about the release and that it actually is named Release or release, some old modules refer to it as Version, which won't work. Lastly check that no tag exists with that version number (format `v#.#.#`), and then run:
+To cut a new release of your module, ensure the `metadata.json` reflects the expected new version of the module, that no tag exists with that version number (format `v#.#.#`), and then update the module `CHANGELOG.md` and `REFERENCE.md` by running:
+
+```plain
+bundle exec rake release:prepare
+```
+
+Commit these changes (likely in a new branch, open a Pull-Request and wait for it to be reviewed and merged).  When ready to ship the new release, ensure you are on the main branch, it is up-to-date, and run:
 
 ```plain
 bundle exec rake release
 ```
+
+This will perform some sanity checks, tag the current commit with the version number, and bump the version number to ensure no conflict will happen by mistake.
 
 ## License
 

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -1,5 +1,45 @@
 require 'puppet_blacksmith/rake_tasks'
 
+class GCGConfig
+  def self.user=(user)
+    @user = user
+  end
+
+  def self.user
+    @user || project.split(%r{[-/]}).first
+  end
+
+  def self.project=(project)
+    @project = project
+  end
+
+  def self.project
+    @project || metadata['name']
+  end
+
+  def self.metadata
+    @metadata ||= Blacksmith::Modulefile.new.metadata
+  end
+
+  def self.tag_pattern=(tag_pattern)
+    @tag_pattern = tag_pattern
+  end
+
+  def self.tag_pattern
+    @tag_pattern || 'v%s'
+  end
+
+  def self.future_release
+    if metadata['version'].match?(/^\d+\.\d+.\d+$/)
+      format(tag_pattern, metadata['version'])
+    else
+      # Not formatted like a release, might be a pre-release and the future
+      # changes should better be under an "unreleased" section.
+      nil
+    end
+  end
+end
+
 desc 'Release via GitHub Actions'
 task :release do
   Blacksmith::RakeTask.new do |t|
@@ -80,46 +120,6 @@ namespace :release do
       end
     end
   else
-    class GCGConfig
-      def self.user=(user)
-        @user = user
-      end
-
-      def self.user
-        @user || project.split(%r{[-/]}).first
-      end
-
-      def self.project=(project)
-        @project = project
-      end
-
-      def self.project
-        @project || metadata['name']
-      end
-
-      def self.metadata
-        @metadata ||= Blacksmith::Modulefile.new.metadata
-      end
-
-      def self.tag_pattern=(tag_pattern)
-        @tag_pattern = tag_pattern
-      end
-
-      def self.tag_pattern
-        @tag_pattern || 'v%s'
-      end
-
-      def self.future_release
-        if metadata['version'].match?(/^\d+\.\d+.\d+$/)
-          format(tag_pattern, metadata['version'])
-        else
-          # Not formatted like a release, might be a pre-release and the future
-          # changes should better be under an "unreleased" section.
-          nil
-        end
-      end
-    end
-
     namespace :porcelain do
       task :changelog do
         # This is taken from lib/github_changelog_generator/task

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -62,7 +62,12 @@ end
 begin
   require 'github_changelog_generator/task'
   require 'puppet_blacksmith'
-
+rescue LoadError
+  desc "Dummy"
+  task "release:porcelain:changelog" do
+    puts "Skipping CHANGELOG.md generation.  Ensure github_changelog_generator is present if you expected it to be generated."
+  end
+else
   class GCGConfig
     def self.user=(user)
       @user = user
@@ -111,12 +116,6 @@ begin
       new_contents = changelog_txt.gsub(%r{\r\n}, "\n")
       File.write(changelog_file, new_contents)
     end
-  end
-rescue LoadError, Blacksmith::Error
-  # No github_changelog_generator or no metadata.json
-  desc "Dummy"
-  task "release:porcelain:changelog" do
-    puts "Skipping CHANGELOG.md generation.  Ensure github_changelog_generator and metadata.json are present if you expected it to be generated."
   end
 end
 

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -137,17 +137,15 @@ else
     generator = GitHubChangelogGenerator::Generator.new(options)
     log = generator.compound_changelog
     output_filename = options[:output].to_s
-    File.write(output_filename, log)
 
     # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715
     require 'rbconfig'
-    if RbConfig::CONFIG['host_os'].match?(/linux/)
+    unless RbConfig::CONFIG['host_os'].match?(/windows/)
       puts 'Fixing line endings...'
-      changelog_file = 'CHANGELOG.md'
-      changelog_txt = File.read(changelog_file)
-      new_contents = changelog_txt.gsub(%r{\r\n}, "\n")
-      File.write(changelog_file, new_contents)
+      log.gsub!("\r\n", "\n")
     end
+
+    File.write(output_filename, log)
     puts "Generated log placed in #{File.absolute_path(output_filename)}"
   end
 end

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -12,7 +12,7 @@ task :release do
   m = Blacksmith::Modulefile.new
   v = m.version
   raise "Refusing to release an RC or build-release (#{v}).\n" +
-        "Please set a semver *release* version." unless v =~ /^\d+\.\d+.\d+$/
+        "Please set a semver *release* version." unless v.match?(/^\d+\.\d+.\d+$/)
 
   # validate that the REFERENCE.md is up2date, if it exists
   Rake::Task['strings:validate:reference'].invoke if File.exist?('REFERENCE.md')
@@ -84,7 +84,7 @@ begin
     options = GitHubChangelogGenerator::Parser.default_options
     options[:user] = GCGConfig.user
     options[:project] = GCGConfig.metadata['name']
-    options[:future_release] = "v#{GCGConfig.metadata['version']}" if GCGConfig.metadata['version'] =~ /^\d+\.\d+.\d+$/
+    options[:future_release] = "v#{GCGConfig.metadata['version']}" if GCGConfig.metadata['version'].match?(/^\d+\.\d+.\d+$/)
     options[:header] = <<~HEADER.chomp
       # Changelog
 
@@ -103,7 +103,7 @@ begin
 
   # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715
   require 'rbconfig'
-  if RbConfig::CONFIG['host_os'] =~ /linux/
+  if RbConfig::CONFIG['host_os'].match?(/linux/)
     task "release:porcelain:changelog" do
       puts 'Fixing line endings...'
       changelog_file = 'CHANGELOG.md'

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -18,6 +18,7 @@ class GCGConfig
   end
 
   def self.metadata
+    require 'puppet_blacksmith'
     @metadata ||= Blacksmith::Modulefile.new.metadata
   end
 
@@ -112,7 +113,6 @@ namespace :release do
   namespace :porcelain do
     begin
       require 'github_changelog_generator/task'
-      require 'puppet_blacksmith'
     rescue LoadError
       desc "Dummy"
       task :changelog do

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -83,8 +83,12 @@ begin
       File.write(changelog_file, new_contents)
     end
   end
-rescue Blacksmith::Error
-  # No metadata.json
+rescue LoadError, Blacksmith::Error
+  # No github_changelog_generator or no metadata.json
+  desc "Dummy"
+  task "release:porcelain:changelog" do
+    puts "Skipping CHANGELOG.md generation.  Ensure github_changelog_generator and metadata.json are present if you expected it to be generated."
+  end
 end
 
 # For backward compatibility

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -109,18 +109,16 @@ namespace :release do
     MESSAGE
   end
 
-  begin
-    require 'github_changelog_generator/task'
-    require 'puppet_blacksmith'
-  rescue LoadError
-    namespace :porcelain do
+  namespace :porcelain do
+    begin
+      require 'github_changelog_generator/task'
+      require 'puppet_blacksmith'
+    rescue LoadError
       desc "Dummy"
       task :changelog do
         puts "Skipping CHANGELOG.md generation.  Ensure github_changelog_generator is present if you expected it to be generated."
       end
-    end
-  else
-    namespace :porcelain do
+    else
       task :changelog do
         # This is taken from lib/github_changelog_generator/task
         # The generator cannot be used because we want to lazyly evaluate

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -80,7 +80,7 @@ begin
       changelog_file = 'CHANGELOG.md'
       changelog_txt = File.read(changelog_file)
       new_contents = changelog_txt.gsub(%r{\r\n}, "\n")
-      File.open(changelog_file, "w") {|file| file.puts new_contents }
+      File.write(changelog_file, new_contents)
     end
   end
 rescue Blacksmith::Error

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -56,7 +56,7 @@ end
 desc "Prepare a release"
 task "release:prepare" do
   Rake::Task["release:porcelain:changelog"].invoke
-  Rake::Task["release:porcelain:reference"].invoke if File.exist?('REFERENCE.md')
+  Rake::Task["strings:generate:reference"].invoke if File.exist?('REFERENCE.md')
 end
 
 begin
@@ -87,12 +87,6 @@ rescue Blacksmith::Error
   # No metadata.json
 end
 
-desc "Generate REFERENCE.md"
-task "release:porcelain:reference", [:debug, :backtrace] do |t, args|
-  patterns = ''
-  Rake::Task['strings:generate:reference'].invoke(patterns, args[:debug], args[:backtrace])
-end
-
 # For backward compatibility
 task :changelog do
   fail <<-ERROR
@@ -109,6 +103,6 @@ task :reference do
   The "reference" task is deprecated.
 
   Prefer "release:prepare" which manage all pre-release steps, or directly run
-  the "release:porcelain:reference" task.
+  the "strings:generate:reference" task.
   ERROR
 end

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -90,6 +90,24 @@ else
     def self.metadata
       @metadata ||= Blacksmith::Modulefile.new.metadata
     end
+
+    def self.tag_pattern=(tag_pattern)
+      @tag_pattern = tag_pattern
+    end
+
+    def self.tag_pattern
+      @tag_pattern || 'v%s'
+    end
+
+    def self.future_release
+      if metadata['version'].match?(/^\d+\.\d+.\d+$/)
+        format(tag_pattern, metadata['version'])
+      else
+        # Not formatted like a release, might be a pre-release and the future
+        # changes should better be under an "unreleased" section.
+        nil
+      end
+    end
   end
 
   task "release:porcelain:changelog" do
@@ -99,7 +117,7 @@ else
     options = GitHubChangelogGenerator::Parser.default_options
     options[:user] = GCGConfig.user
     options[:project] = GCGConfig.metadata['name']
-    options[:future_release] = "v#{GCGConfig.metadata['version']}" if GCGConfig.metadata['version'].match?(/^\d+\.\d+.\d+$/)
+    options[:future_release] = GCGConfig.future_release
     options[:header] = <<~HEADER.chomp
       # Changelog
 

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -55,8 +55,18 @@ end
 
 desc "Prepare a release"
 task "release:prepare" do
+  v = Blacksmith::Modulefile.new.version
   Rake::Task["release:porcelain:changelog"].invoke
   Rake::Task["strings:generate:reference"].invoke if File.exist?('REFERENCE.md')
+  puts <<~MESSAGE
+
+    Please review these changes and commit them to a new branch:
+
+        git checkout -b release-#{v}
+        git commit -m "Release #{v}"
+
+    Then open a Pull-Request and wait for it to be reviewed and merged).
+  MESSAGE
 end
 
 begin

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -84,7 +84,15 @@ else
     end
 
     def self.user
-      @user || metadata['name'].split(%r{[-/]}).first
+      @user || project.split(%r{[-/]}).first
+    end
+
+    def self.project=(project)
+      @project = project
+    end
+
+    def self.project
+      @project || metadata['name']
     end
 
     def self.metadata
@@ -116,7 +124,7 @@ else
     # GCGConfig.user which might be overrider in the module Rakefile.
     options = GitHubChangelogGenerator::Parser.default_options
     options[:user] = GCGConfig.user
-    options[:project] = GCGConfig.metadata['name']
+    options[:project] = GCGConfig.project
     options[:future_release] = GCGConfig.future_release
     options[:header] = <<~HEADER.chomp
       # Changelog

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -102,20 +102,17 @@ else
     log = generator.compound_changelog
     output_filename = options[:output].to_s
     File.write(output_filename, log)
-    puts "Done!"
-    puts "Generated log placed in #{File.absolute_path(output_filename)}"
-  end
 
-  # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715
-  require 'rbconfig'
-  if RbConfig::CONFIG['host_os'].match?(/linux/)
-    task "release:porcelain:changelog" do
+    # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715
+    require 'rbconfig'
+    if RbConfig::CONFIG['host_os'].match?(/linux/)
       puts 'Fixing line endings...'
       changelog_file = 'CHANGELOG.md'
       changelog_txt = File.read(changelog_file)
       new_contents = changelog_txt.gsub(%r{\r\n}, "\n")
       File.write(changelog_file, new_contents)
     end
+    puts "Generated log placed in #{File.absolute_path(output_filename)}"
   end
 end
 

--- a/voxpupuli-release.gemspec
+++ b/voxpupuli-release.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   # Runtime dependencies, but also probably dependencies of requiring projects
+  s.add_runtime_dependency 'github_changelog_generator', '>= 1.16.1'
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'puppet-blacksmith', '>= 4.0.0'
   s.add_runtime_dependency 'puppet-strings', '>= 2.9.0'

--- a/voxpupuli-release.gemspec
+++ b/voxpupuli-release.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   # Runtime dependencies, but also probably dependencies of requiring projects
-  s.add_runtime_dependency 'github_changelog_generator', '>= 1.16.1'
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'puppet-blacksmith', '>= 4.0.0'
   s.add_runtime_dependency 'puppet-strings', '>= 2.9.0'


### PR DESCRIPTION
This is a follow-up to https://github.com/voxpupuli/modulesync_config/pull/788

Voxpupuli contributors used to update a module version and `rake changelog` before opening a PR for preparing a new release.  Some modules now have a REFERENCE.md file that also needs to be updated (by running `rake reference`), and forgetting to do so will remain unnoticed until `rake release` complain that the file is not up-to-date (so after the release PR was reviewed and merged).

This PR move the `changelog` and `reference` tasks from each module's Rakefile (under modulesync control), to the voxpupuli-release gem, rename them to `release:porcelain:changelog` and `release:porcelain:reference` to leave room for new `changelog` and `reference` tasks indicating they are new deprecated, and recommand running the new `release:prepare` task that runs them.

This is indented to help maintainers smoothly update their workflow and provide a framework where additional tasks can be added if need be.
