### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.4"
           - "2.5"
           - "2.6"
           - "2.7"

--- a/voxpupuli-release.gemspec
+++ b/voxpupuli-release.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.licenses    = 'Apache-2.0'
 
+  s.required_ruby_version = '>= 2.5', '< 4'
+
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Ruby 2.4 is EoL. We drop it because newer features won't work with Ruby
2.4 anymore: https://github.com/voxpupuli/voxpupuli-release/pull/44