### PR TITLE
Replace `Depreciated` with `Deprecated`

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -34,9 +34,9 @@ task :release do
   g.push!
 end
 
-desc 'Depreciated: use the "release" task instead'
+desc 'Deprecated: use the "release" task instead'
 task "travis_release" do
-  STDERR.puts "Depreciated: use the 'release' task instead"
+  STDERR.puts "Deprecated: use the 'release' task instead"
   Rake::Task['release'].invoke
 end
 


### PR DESCRIPTION
https://stackoverflow.com/questions/9208091/the-difference-between-deprecated-depreciated-and-obsolete#:~:text=%22Depreciated%22%20means%20%22has%20less,deprecated%20without%20an%20%22i%22.

> “You keep using that word. I do not think it means what you think it means.”
- Inigo Montoya, The Princess Bride