### PR TITLE
dependabot: check for github actions as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,15 @@
 version: 2
 updates:
+# raise PRs for gem updates
 - package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "13:00"
+  open-pull-requests-limit: 10
+
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
this module uses the older checkout action. I would like to check if this dependabot syntax is correct. Then it should provide a PR to update the checkout action.