### PR TITLE
Avoid producing a backtrace for deprecated tasks

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -155,20 +155,22 @@ end
 
 # For backward compatibility
 task :changelog do
-  fail <<-ERROR
+  $stderr.puts <<-ERROR
   The "changelog" task is deprecated.
 
   Prefer "release:prepare" which manage all pre-release steps, or directly run
   the "release:porcelain:changelog" task.
   ERROR
+  exit(1)
 end
 
 # For backward compatibility
 task :reference do
-  fail <<-ERROR
+  $stderr.puts <<-ERROR
   The "reference" task is deprecated.
 
   Prefer "release:prepare" which manage all pre-release steps, or directly run
   the "strings:generate:reference" task.
   ERROR
+  exit(1)
 end


### PR DESCRIPTION
The `changelog` and `reference` tasks have been deprecated and a
deprecation message is displayed when they are called.  But when this
happen, rake output a backtrace that makes the error less visible.

Instead of raising an exception, just display the message and then exit
with an error code.
