### PR TITLE
Encourage a signed commit

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -106,7 +106,7 @@ namespace :release do
       Please review these changes and commit them to a new branch:
 
           git checkout -b release-#{v}
-          git commit -m "Release #{v}"
+          git commit --gpg-sign -m "Release #{v}"
 
       Then open a Pull-Request and wait for it to be reviewed and merged).
     MESSAGE


### PR DESCRIPTION
The commit releases need to be signed. Suggest use of `-S` flag.