### PR TITLE
Add github_changelog_generator & faraday-retry as dependencies

### DIFF
--- a/voxpupuli-release.gemspec
+++ b/voxpupuli-release.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   # Runtime dependencies, but also probably dependencies of requiring projects
+  s.add_runtime_dependency 'faraday-retry', '~> 2.1'
+  s.add_runtime_dependency 'github_changelog_generator', '~> 1.16', '>= 1.16.4'
   s.add_runtime_dependency 'puppet-blacksmith', '~> 7.0'
   s.add_runtime_dependency 'puppet-strings', '~> 4'
   s.add_runtime_dependency 'rake', '~> 13.0', '>= 13.0.6'


### PR DESCRIPTION
The rake tasks we define use those gems, so we should add them as dependencies.