### PR TITLE
release:prep task: actually commit files

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -108,7 +108,7 @@ namespace :release do
       Please review these changes and commit them to a new branch:
 
           git checkout -b release-#{v}
-          git commit --gpg-sign -m "Release #{v}"
+          git commit --gpg-sign -am "Release #{v}"
 
       Then open a Pull-Request and wait for it to be reviewed and merged).
     MESSAGE


### PR DESCRIPTION
The release:prep task outputs git commands for users to commit the changed files. `-a` was missing so the commit didn't commit any files.