### PR TITLE
puppet-modulebuilder: Switch to 2.x; use file allowlist when building…

### DIFF
--- a/voxpupuli-release.gemspec
+++ b/voxpupuli-release.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # Runtime dependencies, but also probably dependencies of requiring projects
   s.add_runtime_dependency 'faraday-retry', '~> 2.1'
   s.add_runtime_dependency 'github_changelog_generator', '~> 1.16', '>= 1.16.4'
-  s.add_runtime_dependency 'puppet-blacksmith', '~> 7.0'
+  s.add_runtime_dependency 'puppet-blacksmith', '~> 8.0'
   s.add_runtime_dependency 'puppet-strings', '~> 4'
   s.add_runtime_dependency 'rake', '~> 13.0', '>= 13.0.6'
 


### PR DESCRIPTION
… modules

This is coming from https://github.com/voxpupuli/puppet-blacksmith/pull/125

I don't think we need to mark this as backwards-incompatible change here because it shouldn't break our modules.