### PR TITLE
Require puppet-strings rake tasks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake --rakefile Rakefile_ci -T | grep release
+      - name: check that required tasks are available
+        run: bundle exec rake --rakefile Rakefile_ci -T | grep --regexp 'rake strings' --regexp 'rake release' --quiet
       - name: Verify gem builds
         run: gem build --strict --verbose *.gemspec
 

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'puppet_blacksmith/rake_tasks'
+require 'puppet-strings/tasks'
 
 class GCGConfig
   class << self


### PR DESCRIPTION
In lib/voxpupuli/release/rake_tasks.rb we call the puppet-strings rake tasks. To make this work, we actually need to require puppet-strings first. This usually works fine by accident in our modules because puppetlabs_spec_helper is loaded.