### PR TITLE
Add puppet as runtime dependency

### DIFF
--- a/voxpupuli-release.gemspec
+++ b/voxpupuli-release.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'github_changelog_generator', '~> 1.16', '>= 1.16.4'
   s.add_dependency 'puppet-blacksmith', '~> 8.0'
   s.add_dependency 'puppet-strings', '~> 4'
+  # workaround for https://github.com/puppetlabs/puppet-strings/pull/404
+  s.add_dependency 'puppet', '>= 7', '< 9'
   s.add_dependency 'rake', '~> 13.0', '>= 13.0.6'
 
   s.add_development_dependency 'voxpupuli-rubocop', '~> 3.0.0'


### PR DESCRIPTION
`puppet` is a runtime dependency for puppet-strings:

https://github.com/puppetlabs/puppet-strings/pull/404

Adding puppet as runtime dependency for voxpupuli-release is our hotfix for the broken puppet-strings.