### PR TITLE
Add racc dependency

### DIFF
--- a/voxpupuli-release.gemspec
+++ b/voxpupuli-release.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'puppet-strings', '~> 4'
   # workaround for https://github.com/puppetlabs/puppet-strings/pull/404
   s.add_dependency 'puppet', '>= 7', '< 9'
+  # workaround for https://github.com/puppetlabs/puppet/issues/9535
+  s.add_dependency 'racc', '~> 1.8', '>= 1.8.1'
   s.add_dependency 'rake', '~> 13.0', '>= 13.0.6'
 
   s.add_development_dependency 'voxpupuli-rubocop', '~> 3.0.0'


### PR DESCRIPTION
puppet depends on the `racc` gem, but it's not listed as an explicity dependency. See https://github.com/puppetlabs/puppet/issues/9535. This often worked in the past by accident because we always installed rubocop. That depends on parser, which in turn pulls in racc.