### PR TITLE
Don't update module version to -rc after release tag

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -70,13 +70,6 @@ task :release do
   g = Blacksmith::Git.new
   Rake::Task['module:tag'].invoke unless g.has_version_tag?(v)
 
-  v_inc = m.increase_version(v)
-  v_new = "#{v_inc}-rc0"
-  ENV['BLACKSMITH_FULL_VERSION'] = v_new
-  Rake::Task['module:bump:full'].invoke
-
-  # push it out, and let GitHub Actions do the release:
-  g.commit_modulefile!(v_new)
   g.push!
 end
 


### PR DESCRIPTION
Up for discussion and not yet tested it. @ekohl and I discussed it during voxconf. If it works, I would like to discuss the change in the community and add more explanation.