### PR TITLE
puppet-blacksmith: Fix condition to allow 9.x & CI: Output bundler environment 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Display Ruby environment
+        run: bundle env
       - name: check that required tasks are available
         run: |
           bundle exec rake --rakefile Rakefile_ci -T '^strings:generate:reference$' | grep --quiet .

--- a/voxpupuli-release.gemspec
+++ b/voxpupuli-release.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday-retry', '~> 2.1'
   s.add_dependency 'github_changelog_generator', '~> 1.16', '>= 1.16.4'
   s.add_dependency 'openvox-strings', '>= 5', '< 7'
-  s.add_dependency 'puppet-blacksmith', '~> 8.0', '< 10'
+  s.add_dependency 'puppet-blacksmith', '>= 8.0', '< 10'
   s.add_dependency 'rake', '~> 13.0', '>= 13.0.6'
 
   s.add_development_dependency 'voxpupuli-rubocop', '~> 4.2.0'


### PR DESCRIPTION
There was a typo that prevented the installation of puppet-blacksmith 9.

---

This makes it easier to debug Ruby failures. We introduced this in gha-puppet:

https://github.com/voxpupuli/gha-puppet/commit/fcf484bf4280d8d80b4a55999d122e81089640bc