### PR TITLE
github_changelog_generator: parse config file

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -122,6 +122,7 @@ namespace :release do
       # The generator cannot be used because we want to lazyly evaluate
       # GCGConfig.user which might be overrider in the module Rakefile.
       options = GitHubChangelogGenerator::Parser.default_options
+      GitHubChangelogGenerator::FileParserChooser.new(options).parse!([])
       options[:user] = GCGConfig.user
       options[:project] = GCGConfig.project
       options[:future_release] = GCGConfig.future_release


### PR DESCRIPTION
Fixes #94 by calling FileParserChooser after  the default options are loaded.