### PR TITLE
Use proper job we can depend on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,10 +54,14 @@ jobs:
         run: gem build --strict --verbose *.gemspec
 
   tests:
+    if: always()
     needs:
       - rubocop_and_matrix
       - test
     runs-on: ubuntu-24.04
     name: Test suite
     steps:
-      - run: echo Test suite completed
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
If the matrix generation failed in the past, the job would still mark the PR as green. We already updated other modules with the new logic.