### PR TITLE
Fix missing variables in release task

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -50,12 +50,15 @@ task :release do
 
   Rake::Task['release:tag_and_push'].invoke
 
+  m = Blacksmith::Modulefile.new
+  v = m.version
   v_inc = m.increase_version(v)
   v_new = "#{v_inc}-rc0"
   ENV['BLACKSMITH_FULL_VERSION'] = v_new
   Rake::Task['module:bump:full'].invoke
 
-  # push it out, and let GitHub Actions do the release:
+  # Push up the new rc version commit.
+  g = Blacksmith::Git.new
   g.commit_modulefile!(v_new)
   g.push!
 end


### PR DESCRIPTION
Some of the local variable declarations got lost in the refactor of the release task into subtasks from #120, causing the task to fail when it tried to update to a new rc version. This patch just readds the module, version and git variables so the task can run to completion.